### PR TITLE
Separate building library and extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,12 +64,18 @@ setup(
     license=LICENSE,
     url='https://github.com/kmike/datrie',
     classifiers=CLASSIFIERS,
+    libraries=[
+        ('libdatrie', dict(
+            sources=LIBDATRIE_FILES,
+            include_dirs=["libdatrie"],
+        ))
+    ],
     ext_modules=[
         Extension("datrie", [
             'src/datrie.c',
             'src/cdatrie.c',
             'src/stdio_ext.c'
-        ] + LIBDATRIE_FILES, include_dirs=['libdatrie'])
+        ], include_dirs=['libdatrie'])
     ],
     tests_require=["pytest", "hypothesis"],
     cmdclass={"test": PyTest}


### PR DESCRIPTION
Hi Mike. I recently learnt how to separate building library and extension in setup.py . I'm not convinced it's any better or worse, but thought I'd share. What do you think? 